### PR TITLE
Fixes #25

### DIFF
--- a/src/main/java/com/velexio/jlegos/data/annotations/DTOField.java
+++ b/src/main/java/com/velexio/jlegos/data/annotations/DTOField.java
@@ -13,5 +13,5 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 public @interface DTOField {
-    DTOClassType[] dtoClassTypes() default {DTOClassType.BASE_DTO};
+    DTOClassType[] dtoClassTypes() default {DTOClassType.BASE_DTO, DTOClassType.CREATE_DTO, DTOClassType.UPDATE_DTO};
 }


### PR DESCRIPTION
Changed the default for the DTOField annotation. Default is now to include on base, create and update dtos.  This will make it so that most of the time only DTOField needs to be added without specifying the longer list of classes.